### PR TITLE
Create a Graph compatibly with rdflib v6

### DIFF
--- a/pyrml/pyrml.py
+++ b/pyrml/pyrml.py
@@ -201,7 +201,7 @@ class AbstractMap(TermMap):
 class ObjectMap(AbstractMap):
     
     def to_rdf(self):
-        g = Graph('IOMemory')
+        g = Graph()
         g.add((self._id, RDF.type, rml_vocab.OBJECT_MAP_CLASS))
         return g
 
@@ -998,7 +998,7 @@ class PredicateObjectMap(AbstractMap):
         return self.__object_map
     
     def to_rdf(self) -> Graph:
-        g = Graph('IOMemory')
+        g = Graph()
         g.add((self._id, RDF.type, rml_vocab.PREDICATE_OBJECT_MAP_CLASS))
         g = graph_add_all(g, self._predicate.to_rdf())
         
@@ -1148,7 +1148,7 @@ class Join(AbstractMap):
         return self.__parent
     
     def to_rdf(self) -> Graph:
-        g = Graph('IOMemory')
+        g = Graph()
         
         if self.__child is not None and self.__parent is not None:
             join = self._id
@@ -1213,7 +1213,7 @@ class LogicalSource(AbstractMap):
         return self.__separator
     
     def to_rdf(self):
-        g = Graph('IOMemory')
+        g = Graph()
         g.add((self._id, RDF.type, rml_vocab.BASE_SOURCE))
         g.add((self._id, rml_vocab.SOURCE, self.get_source()))
         g.add((self._id, rml_vocab.REFERENCE_FORMULATION, self.__reference_formulation))
@@ -1302,7 +1302,7 @@ class GraphMap(AbstractMap):
         
     
     def to_rdf(self):
-        g = Graph('IOMemory')
+        g = Graph()
         
         if isinstance(self._mapped_entity, Literal):
             g.add((self._id, rml_vocab.TEMPLATE, self._mapped_entity))
@@ -1368,7 +1368,7 @@ class SubjectMap(AbstractMap):
         return self.__graph_map
                 
     def to_rdf(self):
-        g = Graph('IOMemory')
+        g = Graph()
         subject_map = self._id
         
         '''
@@ -1549,7 +1549,7 @@ class TripleMappings(AbstractMap):
         return self.__predicate_object_maps.get(identifier)
     
     def to_rdf(self) -> Graph:
-        g = Graph('IOMemory')
+        g = Graph()
         g.add((self._id, RDF.type, rml_vocab.TRIPLES_MAP))
         g.add((self._id, rml_vocab.LOGICAL_SOURCE, self.__logical_source.get_id()))
         g.add((self._id, rml_vocab.SUBJECT_MAP, self.__subject_map.get_id()))
@@ -1595,7 +1595,7 @@ class TripleMappings(AbstractMap):
     def apply(self):
         start_time = time.time()
 
-        g = Graph('IOMemory')
+        g = Graph()
         
         df = self.__logical_source.apply()
         
@@ -1733,7 +1733,7 @@ class TripleMappings(AbstractMap):
     def apply_subject_map(self):
         start_time = time.time()
 
-        g = Graph('IOMemory')
+        g = Graph()
         
         df = self.__logical_source.apply()
         
@@ -1753,7 +1753,7 @@ class TripleMappings(AbstractMap):
         start_time = time.time()
         msg = "\t TripleMapping %s" % self._id
         print(msg)
-        g = Graph('IOMemory')
+        g = Graph()
         
         df = self.__logical_source.apply()
         
@@ -2367,13 +2367,13 @@ class RMLParser():
     
     @staticmethod
     def parse(source, format="ttl"):
-        g = Graph('IOMemory')
+        g = Graph()
         g.parse(source, format=format)
         
         return TripleMappings.from_rdf(g)
         
         '''
-        g_2 = Graph('IOMemory')
+        g_2 = Graph()
         for tm in triple_mappings:
             g_2 += tm.apply()
             g1 = tm.to_rdf()
@@ -2428,7 +2428,7 @@ class RMLConverter():
         
         triple_mappings = RMLParser.parse(rml_mapping)
         
-        g = Graph('IOMemory')
+        g = Graph()
         
         
         if multiprocessed:


### PR DESCRIPTION
The option 'IOMemory' in a rdflib Graph() creation is deprecated in rdflib v6.